### PR TITLE
fix typo in description of the fg command

### DIFF
--- a/src/content/docs/book/part-0-getting-started/2-computer-use/1-concepts/10-signals.md
+++ b/src/content/docs/book/part-0-getting-started/2-computer-use/1-concepts/10-signals.md
@@ -23,7 +23,7 @@ Related to these are some other shell commands:
 | Read input        |`read`       | Read user input into the `$REPLY` environment variable. |
 | List jobs         |`jobs`       | List the programs that are currently suspended or running in the background. |
 | Run in background |`bg`         | Move a program to run in the background. Specify the program with an argument, or by default the last suspended program will be used. |
-| Run in foreground |`fg`         | Move a program to run in the background. Specify the program with an argument, or by default the last suspended program will be used. |
+| Run in foreground |`fg`         | Move a program to run in the foreground. Specify the program with an argument, or by default the last suspended program will be used. |
 
 ## Killing a program (`ctrl-c`)
 


### PR DESCRIPTION
this fixes #20 

not sure if this repo is even open for contribution but the fix seemed simple enough. I checked the description with this [man page](https://man7.org/linux/man-pages/man1/fg.1p.html) and it looks good.