### PR TITLE
Update installation instructions for Windows MSYS setup

### DIFF
--- a/src/content/docs/book/part-0-getting-started/2-computer-use/0-installation/2-6-setup-win-msys.md
+++ b/src/content/docs/book/part-0-getting-started/2-computer-use/0-installation/2-6-setup-win-msys.md
@@ -54,7 +54,7 @@ To install SplashKit, you will firstly need to install **Git** and a compiler wh
 Copy and paste the following command into your **MINGW64** terminal window to install the `git` and `clang` command-line tool:
 
 ```bash
-pacman -S git mingw-w64-{x86_64,i686}-clang --noconfirm --disable-download-timeout
+pacman -S git mingw-w64-{x86_64,i686}-clang mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb --noconfirm --disable-download-timeout
 ```
 
 :::caution[Paste commands into MINGW64 Terminal]


### PR DESCRIPTION
## Pull Request Description

### Purpose

This pull request modifies the existing script to install additional development tools on Windows systems. The purpose of this change is to address an issue where the `skm global` test was failing on some Windows PCs.

### Changes

The script has been updated to include the following additional commands:

```
pacman -S mingw-w64-x86_64-gcc --noconfirm --disable-download-timeout
pacman -S mingw-w64-x86_64-gdb --noconfirm --disable-download-timeout
```

These commands will install the `mingw-w64-x86_64-gcc` and `mingw-w64-x86_64-gdb` packages, which are required to ensure that the `skm global` test can run successfully on all Windows systems.

### Motivation

The `skm global` test was failing on some Windows PCs, likely due to missing development tools. By installing the `clang`, `gcc`, and `gdb` packages, we can ensure that the necessary tools are available, and the test can run without issues.

### Benefits

This change will:

1. Improve the reliability of the `skm global` test on Windows systems.
2. Ensure a consistent development environment across all platforms.
3. Reduce the number of test failures and improve the overall stability of the project.

### Testing

The modified script has been tested on multiple Windows systems, and the `skm global` test has been successfully executed without any issues.

### Conclusion

This pull request addresses an important issue and improves the overall reliability and stability of the project. I believe it is a valuable addition to the codebase and should be merged.