### PR TITLE
Fix incorrect syntax in example

### DIFF
--- a/src/content/docs/book/part-2-organised-code/1-starting-cpp/2-trailside/4-5-while.md
+++ b/src/content/docs/book/part-2-organised-code/1-starting-cpp/2-trailside/4-5-while.md
@@ -50,6 +50,6 @@ int main()
 
         write("Again: ");
         again = read_line();
-    } (again == "y" || again == "Y");
+    } while (again == "y" || again == "Y");
 }
 ```


### PR DESCRIPTION
Forgotten the `while` keyword in the example for the  do-while loop.