### PR TITLE
Fix accordion title

### DIFF
--- a/src/content/docs/book/part-2-organised-code/5-working-with-multiples/1-tour/01-07-stats-remove.mdx
+++ b/src/content/docs/book/part-2-organised-code/5-working-with-multiples/1-tour/01-07-stats-remove.mdx
@@ -108,7 +108,7 @@ Any time you are using something like `i + 1` or `i - 1` to access an array elem
 Have a go at coding this option. Comment out your original code so that you can keep a record of this and go back to it if you want to play with it further.
 
 <Accordion>
-<AccordionItem header="Code for remove using swap">
+<AccordionItem header="Code for remove by shifting">
 
 ```cpp {14-17}
 /**


### PR DESCRIPTION
"Shifting" accordion title seems to be mistakenly duplicated from the "swap" section above.