### PR TITLE
Fix technical errors, broken code examples, and incorrect links

### DIFF
--- a/src/content/docs/book/appendix/0-installation/2-5-setup-win-msys.mdx
+++ b/src/content/docs/book/appendix/0-installation/2-5-setup-win-msys.mdx
@@ -342,7 +342,7 @@ For coding in C#, you will need to install the `.NET` SDK which will allow you t
 
 <Steps>
 
-1. Download the latest version of the .NET SDK (currently .NET 9) for macOS from the official .NET website: [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
+1. Download the latest version of the .NET SDK (currently .NET 10) for Windows from the official .NET website: [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
 
 2. Run the downloaded installer and follow on-screen instructions.
 

--- a/src/content/docs/book/part-0-getting-started/2-computer-use/1-tour/3-2-basics.mdx
+++ b/src/content/docs/book/part-0-getting-started/2-computer-use/1-tour/3-2-basics.mdx
@@ -56,7 +56,7 @@ Open your terminal. Use `cd` to move into your Documents folder. Then use `ls -l
 
 ## Make a folder
 
-When we create programs you will want to keep the program's files together. We can do this by creating a folder for each project. In the terminal you can use the (mkdir)[/book/part-0-getting-started/2-computer-use/2-trailside/05-manipulating-files/#making-a-directory-mkdir] command to make a new folder (make a directory in file system terminology).
+When we create programs you will want to keep the program's files together. We can do this by creating a folder for each project. In the terminal you can use the [mkdir](/book/part-0-getting-started/2-computer-use/2-trailside/05-manipulating-files/#making-a-directory-mkdir) command to make a new folder (make a directory in file system terminology).
 
 ```sh
 # This will create a new folder called - MyNewFolder

--- a/src/content/docs/book/part-1-instructions/1-sequence-and-data/1-tour/01-04-wrap-up.mdx
+++ b/src/content/docs/book/part-1-instructions/1-sequence-and-data/1-tour/01-04-wrap-up.mdx
@@ -42,7 +42,7 @@ Do this in steps! First get the remaining distance and time to destination, then
 
     Write("How long has it taken? Enter minutes: ");
     userInput = ReadLine();
-    time = ToInt32(userInput);
+    time = ToDouble(userInput);
 
     speed = distance / (time / MINUTES_PER_HOUR);
 

--- a/src/content/docs/book/part-1-instructions/1-sequence-and-data/2-trailside/06-type.mdx
+++ b/src/content/docs/book/part-1-instructions/1-sequence-and-data/2-trailside/06-type.mdx
@@ -66,9 +66,9 @@ Typically you will use `int` unless you have a specific reason not to.
 | <div style="width:120px">**Name**</div> | **Size** | **Range (lowest .. highest)** |
 |---------- |--------------------------|---------------------------------------------------------|
 | `byte`    | 1 bytes/8 bits           | 0 .. 255                                                |
-| `short`   | 2 bytes/16 bits          | -32,767 .. 32,767                                       |
+| `short`   | 2 bytes/16 bits          | -32,768 .. 32,767                                       |
 | `int`     | 4 bytes/32 bits          | -2,147,483,648 .. 2,147,483,647                         |
-| `long`    | 8 bytes/64 bits          | -9,223,372,036,854,775,807 .. 9,223,372,036,854,775,807 |
+| `long`    | 8 bytes/64 bits          | -9,223,372,036,854,775,808 .. 9,223,372,036,854,775,807 |
 | `uint`    | 4 bytes/32 bits          | 0 to 4,294,967,295                                      |
 | `ulong`   | 8 bytes/64 bits          | 0 to 18,446,744,073,709,551,615                         |
 
@@ -126,7 +126,7 @@ SplashKit also provides convenient helper methods for this:
 - [ConvertToInteger](https://splashkit.io/api/utilities/#convert-to-integer) - can be used to convert a string to an integer.
 - [ConvertToDouble](https://splashkit.io/api/utilities/#convert-to-double) - can be used to convert a string to a double.
 
-For simple conversions, mostly between different number formats, languages usually also provide an alternate option called **type casting**. With this you can ask the language to reinterpret data in a new format. This is achieved by placing the type within brackets (parenthesis) before the value to be converted. For example, `(int)73.5` will give you the integer 70.
+For simple conversions, mostly between different number formats, languages usually also provide an alternate option called **type casting**. With this you can ask the language to reinterpret data in a new format. This is achieved by placing the type within brackets (parenthesis) before the value to be converted. For example, `(int)73.5` will give you the integer 73.
 
 ## Example
 

--- a/src/content/docs/book/part-1-instructions/2-communicating-syntax/2-trailside/02-statement.md
+++ b/src/content/docs/book/part-1-instructions/2-communicating-syntax/2-trailside/02-statement.md
@@ -35,8 +35,6 @@ Write("We are the keepers of the sacred words:");
 WriteLine(" 'Ni', 'Peng', and 'Neee-wom !'");
 WriteLine("The Knights Who Say 'Ni' demand a sacrifice.");
 WriteLine("We want .... a shrubbery!");
-
-return 0;
 ```
 
 :::note[Summary]

--- a/src/content/docs/book/part-1-instructions/3-control-flow/2-trailside/01-3-conditions.md
+++ b/src/content/docs/book/part-1-instructions/3-control-flow/2-trailside/01-3-conditions.md
@@ -34,10 +34,10 @@ We can compare this to a truth table for the second option, which shows us that 
 | Space Key? | MouseX > 50? | Clicked? | MouseX > 50 and Clicked? (A) | Space Key or A? |
 | --- | --- | --- | --- | --- |
 | false | false | false | false | false |
-| true | false | false | true | true |
-| false | true | false | true | true |
-| true | true | false | true | true |
-| true | false | true | true | true |
+| true | false | false | false | true |
+| false | true | false | false | false |
+| true | true | false | false | true |
+| true | false | true | false | true |
 | false | true | true | true | true |
 | true | true | true | true | true |
 

--- a/src/content/docs/book/part-2-organised-code/1-starting-cpp/2-trailside/4-1-variable-constant.md
+++ b/src/content/docs/book/part-2-organised-code/1-starting-cpp/2-trailside/4-1-variable-constant.md
@@ -68,10 +68,10 @@ int main()
 Key changes include:
 
 - Using different libraries:
-  - We can access the SplashKit library using `#import "splashkit.h`.
+  - We can access the SplashKit library using `#include "splashkit.h"`.
   - We need `using std::to_string;` and `using std::stod;` to gain access to these C++ functions from the standard (`std`) library.
     - The [to_string](https://en.cppreference.com/w/cpp/string/basic_string/to_string) function is used to convert numbers to text.
-    - In C/C++ you can use [stod](https://en.cppreference.com/w/cpp/string/basic_string/stof) to convert a string to a double. There is also [stoi](https://en.cppreference.com/w/cpp/string/basic_string/stol) to convert text to an integer.
+    - In C/C++ you can use [stod](https://en.cppreference.com/w/cpp/string/basic_string/stod) to convert a string to a double. There is also [stoi](https://en.cppreference.com/w/cpp/string/basic_string/stoi) to convert text to an integer.
 - Changing names of identifiers:
   - `WriteLine` is now `write_line`.
   - `Write` becomes `write`.
@@ -79,7 +79,7 @@ Key changes include:
 C/C++ also lacks the elegant **string interpolation** feature we had in C#. This means you cannot easily embed values within your strings. Instead, can use `to_string` to convert numbers into strings, and then use string concatenation (`+`) to combine different strings together.
 
 :::tip[How do we work this out?]
-Finding the appropriate things to call in the libraries of the language you use will take time. The great thing is that you have tools like search engines and AI that can help. A simple search on how to convert a string to an integer in C++ will lead you to the [stod](https://en.cppreference.com/w/cpp/string/basic_string/stof) code, though there are also other options.
+Finding the appropriate things to call in the libraries of the language you use will take time. The great thing is that you have tools like search engines and AI that can help. A simple search on how to convert a string to an integer in C++ will lead you to the [stod](https://en.cppreference.com/w/cpp/string/basic_string/stod) code, though there are also other options.
 :::
 
 Have a go at coding this up yourself, and run the program to see it working. The thought process to create this is the same as before, you just need to switch some details.

--- a/src/content/docs/book/part-2-organised-code/3-structuring-data/2-trailside/03-05-union.md
+++ b/src/content/docs/book/part-2-organised-code/3-structuring-data/2-trailside/03-05-union.md
@@ -23,7 +23,7 @@ A union works best when it is accompanied by a **tag** value. This value then re
 - It is your responsibility to ensure you access the right kind of value when you use a union.
 - A **tag** value can be used to store a marker that indicates the type of data being stored in the union.
 - The **size** of a union is the size of its *largest* option. For example a union of a `char`
-(1 byte), a `int` (4 bytes), and a `double` (4 bytes) would require 4 bytes, the size of the largest kind of value it needs to store.
+(1 byte), a `int` (4 bytes), and a `double` (8 bytes) would require 8 bytes, the size of the largest kind of value it needs to store.
 
 :::
 

--- a/src/content/docs/book/part-2-organised-code/9-low-level-programming/2-trailside/1-dcc.md
+++ b/src/content/docs/book/part-2-organised-code/9-low-level-programming/2-trailside/1-dcc.md
@@ -20,7 +20,7 @@ TODO: Add instructions for installing DCC on the Raspberry Pi
 
 ### On your own computer
 
-You can refer to this handy guide for installation which will stay updated as DCC evolves: [https://github.com/COMP1511UNSW/dcc#installation](DCC Installation Guide)
+You can refer to this handy guide for installation which will stay updated as DCC evolves: [DCC Installation Guide](https://github.com/COMP1511UNSW/dcc#installation)
 
 On Windows we suggest you use WSL2. Follow the [WSL Installation Guide](/book/appendix/0-installation/2-6-setup-win-wsl#1-install-windows-subsystem-for-linux-wsl) in this book, and then install DCC on your WSL2 instance.
 

--- a/src/content/docs/book/part-3-programs-as-concepts/1-back-to-c-sharp/2-trailside/5-parameters.md
+++ b/src/content/docs/book/part-3-programs-as-concepts/1-back-to-c-sharp/2-trailside/5-parameters.md
@@ -19,7 +19,7 @@ In C#, parameters are very similar to parameters in C/C++. By default, parameter
 
 ## Example
 
-See the examples in the [static method'](/book/part-3-programs-as-concepts/1-back-to-c-sharp/2-trailside/4-static-methods) page. The following example includes a parameter passed by reference. Notice that you also have to use the `ref` keyword in the method call as well. This helps highlight the fact that the value is being passed by reference, and that the passed variable's value may be changed in the call.
+See the examples in the [static method](/book/part-3-programs-as-concepts/1-back-to-c-sharp/2-trailside/4-static-methods) page. The following example includes a parameter passed by reference. Notice that you also have to use the `ref` keyword in the method call as well. This helps highlight the fact that the value is being passed by reference, and that the passed variable's value may be changed in the call.
 
 ```cs
 class MyProgram

--- a/src/content/docs/book/part-3-programs-as-concepts/2-abstraction/2-trailside/2-1-value-and-reference-types.md
+++ b/src/content/docs/book/part-3-programs-as-concepts/2-abstraction/2-trailside/2-1-value-and-reference-types.md
@@ -23,7 +23,7 @@ A variable of a value type will store a value directly - just like variables in 
 | Parameters  | `void Method(int x) { }` | The value is copied from y and stored in x. There are two values in memory.  |
 | | `Method(y);` | |
 
-Value types in C# include the primitive types such as `int`, `double`, and `boolean` but also include [structs](/book/part-2-organised-code/3-structuring-data/2-trailside/03-01-struct) which you can define.
+Value types in C# include the primitive types such as `int`, `double`, and `bool` but also include [structs](/book/part-2-organised-code/3-structuring-data/2-trailside/03-01-struct) which you can define.
 
 :::caution
 

--- a/src/content/docs/book/part-3-programs-as-concepts/3-collections/2-trailside/23-debugging.mdx
+++ b/src/content/docs/book/part-3-programs-as-concepts/3-collections/2-trailside/23-debugging.mdx
@@ -66,6 +66,7 @@ class Program
         Console.WriteLine("Temperature on day " + i + " is " + temperatures[i]);
     }
   }
+}
 ```
 <div class="caption">Using the Debugger</div>
 

--- a/src/content/docs/book/part-3-programs-as-concepts/3-collections/2-trailside/25-syntax-guide.mdx
+++ b/src/content/docs/book/part-3-programs-as-concepts/3-collections/2-trailside/25-syntax-guide.mdx
@@ -71,13 +71,13 @@ The for loop in the following code initialises an `i` *index* variable, and loop
 
 ```cs
 int[] temperatures = { 22, 22, 23, 24, 24, 22 };
-for ( int i; i < temperatures.Length; i++ )
+for ( int i = 0; i < temperatures.Length; i++ )
 {
    Console.WriteLine(temperatures[i]);
 }
 
 int i = 0;
-while (i < temperatures.Length;)
+while (i < temperatures.Length)
 {
    Console.WriteLine(temperatures[i]);
    i++;

--- a/src/content/docs/book/part-3-programs-as-concepts/4-collaboration/2-trailside/07-returning-data.mdx
+++ b/src/content/docs/book/part-3-programs-as-concepts/4-collaboration/2-trailside/07-returning-data.mdx
@@ -38,14 +38,14 @@ public class Ship
     }
 
     // A private field to store the y position of the ship
-    private double _x;
+    private double _y;
 
     // A property to allow others outside the class to access
     // the Ship's Y position - can be read and written to. 
-    public double X
+    public double Y
     {
-        get { return _x; }
-        set { _x = value; }
+        get { return _y; }
+        set { _y = value; }
     }
 
     // A method that returns true if the ship has

--- a/src/content/docs/book/part-3-programs-as-concepts/4-collaboration/2-trailside/16-syntax-guide.mdx
+++ b/src/content/docs/book/part-3-programs-as-concepts/4-collaboration/2-trailside/16-syntax-guide.mdx
@@ -171,13 +171,13 @@ import imgProperties from './images/sit771-properties.png';
 <div class="caption">This diagram shows the syntax for properties.</div><br/>
 
 ```cs
-public class Shape()
+public class Shape
 {
   private int _x;
   public int X
   {
-    get {return _x};
-    set { _x = value };
+    get { return _x; }
+    set { _x = value; }
   }
 }
 ```
@@ -187,12 +187,12 @@ The `get` and `set` keywords tell us that this property has access to getting an
 A common pattern is to omit the `set`, which says that this field is `readonly`:
 
 ```cs
-public class Shape()
+public class Shape
 {
   private int _x;
   public int X
   {
-    get {return _x};
+    get { return _x; }
   }
 }
 ```
@@ -200,7 +200,7 @@ public class Shape()
 We can also use **auto-implemented properties**, which are a helpful and quicker way to create a field and property. The following code will have a public `X` property, and a private field.
 
 ```cs
-public class Shape()
+public class Shape
 {
   public int X { get; set; }
 }
@@ -338,9 +338,9 @@ public class StorageTank
 
   public void Draw(Window w)
   {
-    double topY = y + height - height * PercentFull;
-    w.FillRectangle(LiquidColor, x, topY, x + width, y + height);
-    w.DrawRectangle(Color.Black, x, y, x + width, y + height);
+    double topY = _y + _height - _height * PercentFull;
+    w.FillRectangle(LiquidColor, _x, topY, _x + _width, _y + _height);
+    w.DrawRectangle(Color.Black, _x, _y, _x + _width, _y + _height);
   }
 }
 ```

--- a/src/content/docs/book/part-3-programs-as-concepts/7-abstract-interfaces/2-trailside/06-delegates-and-lambda-expressions.mdx
+++ b/src/content/docs/book/part-3-programs-as-concepts/7-abstract-interfaces/2-trailside/06-delegates-and-lambda-expressions.mdx
@@ -66,7 +66,7 @@ Comparison<StockItem> compare;
 compare = (StockItem item1, StockItem item2) => item1.Name.CompareTo ( item2.Name );
 ~~~
 
-The lambda itself is the code `(StockItem item1, StockItem item2) -> item1.Name.CompareTo ( item2.Name );`. The names in the brackets are the parameters going into this method, with the code after the `=>` being the statement that this lambda will run. If you want to run multiple statements in the lambda, you can use the **compound statement** (`{...}`) to group these together.
+The lambda itself is the code `(StockItem item1, StockItem item2) => item1.Name.CompareTo ( item2.Name );`. The names in the brackets are the parameters going into this method, with the code after the `=>` being the statement that this lambda will run. If you want to run multiple statements in the lambda, you can use the **compound statement** (`{...}`) to group these together.
 
 In many cases the compiler can work out the types of the parameters for us, so you will often see lambda expressions where the parameter types are omitted. For example, the following code is identical to the above code as the C# compiler knows that the delegate needs to take in two `StockItem` parameters.
 


### PR DESCRIPTION
## Summary

While re-reading the guide to refresh on some C# concepts, I noticed a few inaccuracies. I decided to do a thorough review of the documentation and found several issues across type documentation, code examples, truth tables, and links that could mislead or confuse learners.

## Changes

### Technical errors in type documentation
- `(int)73.5` shown as giving `70`: actually gives `73` (truncation toward zero, not rounding to nearest 10)
- `short` min range listed as `-32,767`: corrected to `-32,768` (two's complement: -2^15)
- `long` min range off by one: corrected to `-9,223,372,036,854,775,808` (-2^63)
- `double` described as 4 bytes in union example: corrected to 8 bytes (IEEE 754), union size updated accordingly
- `boolean` used as C# type: C# uses `bool`, `boolean` is Java
- Lambda uses `->` instead of `=>`: C# lambda operator is `=>`, `->` is C++/Python
- MSYS2 .NET install says "for macOS": this is the Windows setup page; also updated .NET 9 to .NET 10

### Code examples that won't compile
- `ToInt32` used on a `double` variable: `time` is declared as `double`, all prior steps use `ToDouble`. Using `ToInt32` silently truncates decimal input
- `return 0;` in C# top-level statements: invalid syntax, causes compiler error CS8803
- Ship class declares `_x` twice, missing `_y`: copy-paste error. Second field and property should be `_y`/`Y`. As written, causes compiler error CS0102
- For loop variable never initialized: `for (int i; i < ...)` fails with definite assignment error CS0165. Also `while (i < temperatures.Length;)` has an invalid semicolon inside the condition
- Missing closing brace: `Program` class never closed (11 opening braces vs 10 closing)
- Multiple syntax errors in collaboration syntax guide: `public class Shape()` has invalid parentheses, property accessors have semicolons outside braces (`get {return _x};` should be `get { return _x; }`), and `Draw` method references `x`/`y`/`width`/`height` but the fields are `_x`/`_y`/`_width`/`_height`

### Truth table errors
- Second truth table for compound conditions has wrong values: `MouseX > 50 AND Clicked` column was `true` in rows where `Clicked` is `false`, which is impossible. Corrected all affected rows

### Broken markdown and links
- Brackets and parens swapped on mkdir link: `(mkdir)[/book/...]` renders as broken text, swapped to `[mkdir](/book/...)`
- DCC link syntax reversed: `[URL](Display Text)` instead of `[Display Text](URL)`
- Stray apostrophe in link text: `[static method']` changed to `[static method]`
- `#import` instead of `#include`: `#import` is Objective-C, C++ uses `#include`. Also added missing closing quote on `"splashkit.h`
- cppreference links point to wrong functions: `stod` link went to the `stof` page, `stoi` link went to the `stol` page. Corrected both URLs

## Test plan

- [x] Verified all changes render correctly on local dev server
- [x] Cross-referenced type values against official C#/.NET documentation
- [x] Verified corrected cppreference URLs resolve to the correct function pages
- [x] Checked truth table values by hand against boolean logic